### PR TITLE
fix validate headers response

### DIFF
--- a/app/src/main/java/org/flyve/inventory/agent/utils/HttpInventory.java
+++ b/app/src/main/java/org/flyve/inventory/agent/utils/HttpInventory.java
@@ -193,10 +193,16 @@ public class HttpInventory {
                     FlyveLog.log(this, "No HTTP response ", Log.ERROR);
                     callback.onTaskError(appContext.getResources().getString(R.string.error_server_not_response));
                 }
-                Header[] headers = response.getAllHeaders();
-                for (Header header : headers) {
-                    FlyveLog.log(this, header.getName() + " -> " + header.getValue(), Log.INFO);
+
+                try {
+                    Header[] headers = response.getAllHeaders();
+                    for (Header header : headers) {
+                        FlyveLog.log(this, header.getName() + " -> " + header.getValue(), Log.INFO);
+                    }
+                } catch (Exception ex) {
+                    FlyveLog.e(ex.getMessage());
                 }
+
                 try {
                     InputStream mIS = response.getEntity().getContent();
                     BufferedReader r = new BufferedReader(new InputStreamReader(mIS));


### PR DESCRIPTION
This PR works with:

- Solved the problem reported by Android Bugsnag:

```
"errorClass": "java.lang.NullPointerException",
"message": "Attempt to invoke interface method 'org.apache.http.Header[] org.apache.http.HttpResponse.getAllHeaders()' on a null object reference",
```

[Android.Bugsnag.zip](https://github.com/flyve-mdm/flyve-mdm-android-inventory-agent/files/1368759/Android.Bugsnag.zip)


