### PR TITLE
Restore API version 25 for test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: yes | sdkmanager --licenses || true
       - run:
           name: Setup emulator
-          command: sdkmanager "system-images;android-22;google_apis;armeabi-v7a" && echo "no" | avdmanager create avd -n test -k "system-images;android-22;google_apis;armeabi-v7a"
+          command: sdkmanager "system-images;android-25;google_apis;armeabi-v7a" && echo "no" | avdmanager create avd -n test -k "system-images;android-25;google_apis;armeabi-v7a"
       - run:
           name: Launch emulator
           command: export LD_LIBRARY_PATH=${ANDROID_HOME}/emulator/lib64:${ANDROID_HOME}/emulator/lib64/qt/lib && emulator64-arm -avd test -noaudio -no-boot-anim -no-window -accel on


### PR DESCRIPTION
Hi @ajsb85 / @hectorerb 
This PR works with:

- Restore de API version 25 for the test, we are working with a docker alpha version from CircleCI https://hub.docker.com/r/circleci/android/tags/ they update this version really often and in some case create incompatibilities with versions and some test with the newest API fails, we need check first if they are updating and wait to make changes.
